### PR TITLE
Refine Vue SDK tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,4 +6,7 @@ module.exports = {
     '@fingerprintjs/eslint-config-dx-team',
     'plugin:@typescript-eslint/eslint-recommended',
   ],
+  rules: {
+    '@typescript-eslint/no-non-null-assertion': 'error',
+  },
 }

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -42,7 +42,6 @@ export function getMountedFingerprintClient(options: FingerprintPluginOptions = 
 
   const app = createAppWithPlugin(
     defineComponent({
-      template: '<div />',
       setup() {
         const instance = getCurrentInstance()
 
@@ -54,6 +53,7 @@ export function getMountedFingerprintClient(options: FingerprintPluginOptions = 
 
         return {}
       },
+      template: '<div />',
     }),
     options
   )

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -64,6 +64,10 @@ export function getMountedFingerprintClient(options: FingerprintPluginOptions = 
     throw new Error('Expected mounted component to expose $fingerprint')
   }
 
+  // The captured $fingerprint closure survives teardown, so we can unmount the
+  // throwaway app here and avoid leaking Vue app instances across tests.
+  app.unmount()
+
   return fingerprint
 }
 

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,0 +1,86 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createApp, defineComponent, getCurrentInstance } from 'vue'
+import { FingerprintPlugin } from '../src'
+import type { FingerprintPluginOptions, FingerprintVueGlobalClient } from '../src'
+
+export const apiKey = 'API_KEY'
+
+export const testData = {
+  visitor_id: '#visitor_id',
+  event_id: 'event123',
+  sealed_result: null,
+}
+
+export const pluginConfig: FingerprintPluginOptions = {
+  apiKey,
+}
+
+export const EmptyComponent = { template: '<div />' }
+
+export function mountWithPlugin(component: Parameters<typeof mount>[0], options?: Parameters<typeof mount>[1]) {
+  return mount(component, {
+    ...options,
+    global: {
+      ...options?.global,
+      plugins: [...(options?.global?.plugins ?? []), [FingerprintPlugin, pluginConfig]],
+    },
+  })
+}
+
+export function createAppWithPlugin(
+  rootComponent: Parameters<typeof createApp>[0] = EmptyComponent,
+  options: FingerprintPluginOptions = pluginConfig
+) {
+  const app = createApp(rootComponent)
+  app.use(FingerprintPlugin, options)
+
+  return app
+}
+
+export function getMountedFingerprintClient(options: FingerprintPluginOptions = pluginConfig) {
+  let fingerprint: FingerprintVueGlobalClient | undefined
+
+  const app = createAppWithPlugin(
+    defineComponent({
+      template: '<div />',
+      setup() {
+        const instance = getCurrentInstance()
+
+        if (!instance?.proxy?.$fingerprint) {
+          throw new Error('Expected $fingerprint on the component instance')
+        }
+
+        fingerprint = instance.proxy.$fingerprint
+
+        return {}
+      },
+    }),
+    options
+  )
+
+  app.mount(document.createElement('div'))
+
+  if (!fingerprint) {
+    throw new Error('Expected mounted component to expose $fingerprint')
+  }
+
+  return fingerprint
+}
+
+export function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return {
+    promise,
+    resolve,
+    reject,
+  }
+}
+
+export { flushPromises }

--- a/__tests__/mixin.test.ts
+++ b/__tests__/mixin.test.ts
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { fingerprintGetVisitorDataMixin } from '../src'
-import { defineComponent, nextTick } from 'vue'
+import { defineComponent } from 'vue'
 import { deferred, mountWithPlugin, testData } from './helpers'
 import { mockGet, mockStart } from './setup'
 

--- a/__tests__/mixin.test.ts
+++ b/__tests__/mixin.test.ts
@@ -1,8 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { fingerprintGetVisitorDataMixin } from '../src'
-import { defineComponent } from 'vue'
-import { wait } from '../src/utils'
+import { defineComponent, nextTick } from 'vue'
 import { deferred, mountWithPlugin, testData } from './helpers'
 import { mockGet, mockStart } from './setup'
 
@@ -43,7 +42,6 @@ describe('fingerprintGetVisitorDataMixin', () => {
     })
 
     pending.resolve(testData)
-    await wait(0)
     await request
 
     expect(vm.visitorData).toEqual({

--- a/__tests__/mixin.test.ts
+++ b/__tests__/mixin.test.ts
@@ -1,99 +1,60 @@
-import { config, mount } from '@vue/test-utils'
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { FingerprintPlugin, fingerprintGetVisitorDataMixin } from '../src'
-import type { FingerprintPluginOptions } from '../src'
-import { defineComponent, nextTick } from 'vue'
-import { mockGet, mockStart } from './setup'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { fingerprintGetVisitorDataMixin } from '../src'
+import { defineComponent } from 'vue'
 import { wait } from '../src/utils'
+import { deferred, mountWithPlugin, testData } from './helpers'
+import { mockGet, mockStart } from './setup'
 
-const apiKey = 'API_KEY'
-const testData = {
-  visitor_id: '#visitor_id',
-  event_id: 'event123',
-  sealed_result: null,
-}
-
-const pluginConfig: FingerprintPluginOptions = {
-  apiKey,
-}
-
-describe('FingerprintPlugin - mixins', () => {
-  beforeAll(() => {
-    config.global.plugins.push([FingerprintPlugin, pluginConfig])
+function mountMixinComponent() {
+  return mountWithPlugin({
+    mixins: [fingerprintGetVisitorDataMixin],
+    template: '<h1>hello world</h1>',
   })
+}
 
+describe('fingerprintGetVisitorDataMixin', () => {
   beforeEach(() => {
-    mockGet.mockClear()
+    mockGet.mockReset()
     mockStart.mockClear()
   })
 
-  it('should fetch visitor data and update state through full lifecycle', async () => {
-    mockGet.mockImplementation(async () => {
-      await wait(400)
+  it('fetches visitor data and updates state through loading and success', async () => {
+    const pending = deferred<typeof testData>()
+    mockGet.mockReturnValueOnce(pending.promise)
 
-      return testData
-    })
-
-    const { vm } = mount({
-      mixins: [fingerprintGetVisitorDataMixin],
-
-      template: '<h1>hello world</h1>',
-    })
-
-    const spy = vi.spyOn(vm.$fingerprint, 'getVisitorData')
+    const { vm } = mountMixinComponent()
 
     expect(vm.$getVisitorData).toBeDefined()
-    expect(vm.visitorData).toBeDefined()
-    expect(vm.visitorData).toMatchInlineSnapshot(`
-{
-  "data": undefined,
-  "error": undefined,
-  "isFetched": false,
-  "isLoading": false,
-}
-`)
-
-    vm.$getVisitorData?.()
-
-    expect(vm.visitorData?.isLoading).toBe(true)
-
-    await wait(450)
-
-    expect(vm.visitorData).toMatchInlineSnapshot(`
-{
-  "data": {
-    "event_id": "event123",
-    "sealed_result": null,
-    "visitor_id": "#visitor_id",
-  },
-  "error": undefined,
-  "isFetched": true,
-  "isLoading": false,
-}
-`)
-
-    expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith(undefined)
-  })
-
-  it('should populate data correctly', async () => {
-    mockGet.mockResolvedValue(testData)
-
-    const { vm } = mount({
-      mixins: [fingerprintGetVisitorDataMixin],
-
-      template: '<h1>hello world</h1>',
+    expect(vm.visitorData).toEqual({
+      data: undefined,
+      error: undefined,
+      isFetched: false,
+      isLoading: false,
     })
 
-    await vm.$getVisitorData?.()
+    const request = vm.$getVisitorData?.()
 
-    expect(vm.visitorData?.data).toEqual(testData)
-    expect(vm.visitorData?.isFetched).toBe(true)
-    expect(vm.visitorData?.isLoading).toBe(false)
-    expect(vm.visitorData?.error).toBeUndefined()
+    expect(vm.visitorData).toEqual({
+      data: undefined,
+      error: undefined,
+      isFetched: false,
+      isLoading: true,
+    })
+
+    pending.resolve(testData)
+    await wait(0)
+    await request
+
+    expect(vm.visitorData).toEqual({
+      data: testData,
+      error: undefined,
+      isFetched: true,
+      isLoading: false,
+    })
   })
 
-  it('should reuse the same agent across multiple mixin instances', async () => {
+  it('reuses the same agent across multiple mixin instances', async () => {
     mockGet.mockResolvedValue(testData)
 
     const Child = defineComponent({
@@ -101,7 +62,7 @@ describe('FingerprintPlugin - mixins', () => {
       template: '<h1>hello world</h1>',
     })
 
-    const wrapper = mount({
+    const wrapper = mountWithPlugin({
       components: { Child },
       template: '<div><Child ref="first" /><Child ref="second" /></div>',
     })
@@ -109,77 +70,63 @@ describe('FingerprintPlugin - mixins', () => {
     const first = wrapper.getComponent({ ref: 'first' }).vm
     const second = wrapper.getComponent({ ref: 'second' }).vm
 
-    await first.$getVisitorData?.()
-    await second.$getVisitorData?.({ tag: 'second-instance' })
+    await first.$getVisitorData()
+    await second.$getVisitorData({ tag: 'second-instance' })
 
     expect(mockGet).toHaveBeenCalledTimes(2)
     expect(mockStart).toHaveBeenCalledTimes(1)
   })
 
-  it('should handle errors correctly', async () => {
+  it('stores errors without marking the fetch as complete', async () => {
     const testError = new Error('Test error')
     mockGet.mockRejectedValue(testError)
 
-    const { vm } = mount({
-      mixins: [fingerprintGetVisitorDataMixin],
-
-      template: '<h1>hello world</h1>',
-    })
+    const { vm } = mountMixinComponent()
 
     await vm.$getVisitorData?.()
 
-    expect(vm.visitorData?.data).toBeUndefined()
-    expect(vm.visitorData?.error).toEqual(testError)
-    expect(vm.visitorData?.isFetched).toBe(false)
-    expect(vm.visitorData?.isLoading).toBe(false)
+    expect(vm.visitorData).toEqual({
+      data: undefined,
+      error: testError,
+      isFetched: false,
+      isLoading: false,
+    })
   })
 
-  it('should pass options to getVisitorData', async () => {
+  it('normalizes non-Error rejections into Error objects', async () => {
+    mockGet.mockRejectedValue('Test error')
+
+    const { vm } = mountMixinComponent()
+
+    await vm.$getVisitorData?.()
+
+    const { visitorData } = vm
+
+    if (!visitorData) {
+      throw new Error('Expected visitorData to be defined')
+    }
+
+    expect(visitorData.error).toBeInstanceOf(Error)
+    expect(visitorData.error?.message).toBe('Test error')
+    expect(visitorData.isFetched).toBe(false)
+  })
+
+  it('passes options to getVisitorData', async () => {
     mockGet.mockResolvedValue(testData)
 
-    const { vm } = mount({
-      mixins: [fingerprintGetVisitorDataMixin],
-
-      template: '<h1>hello world</h1>',
-    })
+    const { vm } = mountMixinComponent()
 
     await vm.$getVisitorData?.({ tag: 'test-tag', linkedId: 'link123' })
 
     expect(mockGet).toHaveBeenCalledWith({ tag: 'test-tag', linkedId: 'link123' })
   })
 
-  it('should clear stale data immediately when getVisitorData is called again', async () => {
-    mockGet.mockResolvedValueOnce(testData)
-
-    let resolveSecond!: (value: typeof testData) => void
-    mockGet.mockReturnValueOnce(
-      new Promise<typeof testData>((resolve) => {
-        resolveSecond = resolve
-      })
-    )
-
+  it('throws when the plugin is missing', async () => {
     const { vm } = mount({
       mixins: [fingerprintGetVisitorDataMixin],
       template: '<h1>hello world</h1>',
     })
 
-    await vm.$getVisitorData?.()
-
-    expect(vm.visitorData?.data).toEqual(testData)
-    expect(vm.visitorData?.isFetched).toBe(true)
-
-    const pending = vm.$getVisitorData?.({ tag: 'retry' })
-    await nextTick()
-
-    expect(vm.visitorData?.isLoading).toBe(true)
-    expect(vm.visitorData?.data).toBeUndefined()
-    expect(vm.visitorData?.error).toBeUndefined()
-    expect(vm.visitorData?.isFetched).toBe(false)
-
-    resolveSecond(testData)
-    await pending
-
-    expect(vm.visitorData?.data).toEqual(testData)
-    expect(vm.visitorData?.isFetched).toBe(true)
+    await expect(vm.$getVisitorData?.()).rejects.toThrow('$fingerprint is not defined.')
   })
 })

--- a/__tests__/mixin.test.ts
+++ b/__tests__/mixin.test.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { assert, beforeEach, describe, expect, it } from 'vitest'
 import { fingerprintGetVisitorDataMixin } from '../src'
 import { defineComponent } from 'vue'
 import { deferred, mountWithPlugin, testData } from './helpers'
@@ -24,7 +24,6 @@ describe('fingerprintGetVisitorDataMixin', () => {
 
     const { vm } = mountMixinComponent()
 
-    expect(vm.$getVisitorData).toBeDefined()
     expect(vm.visitorData).toEqual({
       data: undefined,
       error: undefined,
@@ -32,7 +31,8 @@ describe('fingerprintGetVisitorDataMixin', () => {
       isLoading: false,
     })
 
-    const request = vm.$getVisitorData?.()
+    assert(vm.$getVisitorData, 'Expected mixin to expose $getVisitorData')
+    const request = vm.$getVisitorData()
 
     expect(vm.visitorData).toEqual({
       data: undefined,
@@ -81,7 +81,8 @@ describe('fingerprintGetVisitorDataMixin', () => {
 
     const { vm } = mountMixinComponent()
 
-    await vm.$getVisitorData?.()
+    assert(vm.$getVisitorData, 'Expected mixin to expose $getVisitorData')
+    await vm.$getVisitorData()
 
     expect(vm.visitorData).toEqual({
       data: undefined,
@@ -96,7 +97,8 @@ describe('fingerprintGetVisitorDataMixin', () => {
 
     const { vm } = mountMixinComponent()
 
-    await vm.$getVisitorData?.()
+    assert(vm.$getVisitorData, 'Expected mixin to expose $getVisitorData')
+    await vm.$getVisitorData()
 
     const { visitorData } = vm
 
@@ -114,7 +116,8 @@ describe('fingerprintGetVisitorDataMixin', () => {
 
     const { vm } = mountMixinComponent()
 
-    await vm.$getVisitorData?.({ tag: 'test-tag', linkedId: 'link123' })
+    assert(vm.$getVisitorData, 'Expected mixin to expose $getVisitorData')
+    await vm.$getVisitorData({ tag: 'test-tag', linkedId: 'link123' })
 
     expect(mockGet).toHaveBeenCalledWith({ tag: 'test-tag', linkedId: 'link123' })
   })
@@ -125,6 +128,7 @@ describe('fingerprintGetVisitorDataMixin', () => {
       template: '<h1>hello world</h1>',
     })
 
-    await expect(vm.$getVisitorData?.()).rejects.toThrow('$fingerprint is not defined.')
+    assert(vm.$getVisitorData, 'Expected mixin to expose $getVisitorData')
+    await expect(vm.$getVisitorData()).rejects.toThrow('$fingerprint is not defined.')
   })
 })

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -19,13 +19,13 @@ describe('FingerprintPlugin', () => {
   it('exposes $fingerprint.getVisitorData on component instances', () => {
     mountWithPlugin(
       defineComponent({
-        template: '<h1>Hello world</h1>',
         mounted() {
           const { $fingerprint } = this
 
           expect($fingerprint).toBeDefined()
           expect(typeof $fingerprint.getVisitorData).toBe('function')
         },
+        template: '<h1>Hello world</h1>',
       })
     )
   })

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { FingerprintPlugin } from '../src'
+import type { FingerprintPluginOptions } from '../src'
 import { INTEGRATION_INFO_PACKAGE_NAME } from '../src/plugin'
 import '../src/vue'
 import { mockGet, mockStart } from './setup'
@@ -51,6 +52,13 @@ describe('FingerprintPlugin', () => {
       const app = createApp(EmptyComponent)
       app.use(FingerprintPlugin, deprecatedOptions)
     }).toThrow(/loadOptions/)
+  })
+
+  it('throws when apiKey is missing', () => {
+    expect(() => {
+      const app = createApp(EmptyComponent)
+      app.use(FingerprintPlugin, undefined as unknown as FingerprintPluginOptions)
+    }).toThrow(/apiKey/)
   })
 
   it('rejects getVisitorData outside the browser before starting the agent', async () => {

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { FingerprintPlugin } from '../src'
+import { INTEGRATION_INFO_PACKAGE_NAME } from '../src/plugin'
 import '../src/vue'
 import { mockGet, mockStart } from './setup'
 import * as packageInfo from '../package.json'
@@ -75,7 +76,7 @@ describe('FingerprintPlugin', () => {
     expect(mockStart).toHaveBeenCalledWith(
       expect.objectContaining({
         apiKey: 'test-key',
-        integrationInfo: expect.arrayContaining([`fingerprintjs-pro-vue-v3/${packageInfo.version}`]),
+        integrationInfo: expect.arrayContaining([`${INTEGRATION_INFO_PACKAGE_NAME}/${packageInfo.version}`]),
       })
     )
   })
@@ -93,7 +94,10 @@ describe('FingerprintPlugin', () => {
     expect(mockStart).toHaveBeenCalledTimes(1)
     expect(mockStart).toHaveBeenCalledWith(
       expect.objectContaining({
-        integrationInfo: expect.arrayContaining(['custom/1.0', `fingerprintjs-pro-vue-v3/${packageInfo.version}`]),
+        integrationInfo: expect.arrayContaining([
+          'custom/1.0',
+          `${INTEGRATION_INFO_PACKAGE_NAME}/${packageInfo.version}`,
+        ]),
       })
     )
   })

--- a/__tests__/plugin.test.ts
+++ b/__tests__/plugin.test.ts
@@ -1,110 +1,100 @@
-import { config, mount } from '@vue/test-utils'
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { FingerprintPlugin } from '../src'
-import type { FingerprintPluginOptions } from '../src'
 import '../src/vue'
 import { mockGet, mockStart } from './setup'
 import * as packageInfo from '../package.json'
-import { createApp } from 'vue'
-import { INTEGRATION_INFO_PACKAGE_NAME } from '../src/plugin'
-
-const apiKey = 'API_KEY'
-const testData = {
-  visitor_id: '#visitor_id',
-  event_id: 'event123',
-  sealed_result: null,
-}
-
-const pluginConfig: FingerprintPluginOptions = {
-  apiKey,
-}
-
-const EmptyComponent = { template: '<div />' }
+import { createApp, defineComponent } from 'vue'
+import { EmptyComponent, getMountedFingerprintClient, mountWithPlugin, testData } from './helpers'
 
 describe('FingerprintPlugin', () => {
-  beforeAll(() => {
-    config.global.plugins.push([FingerprintPlugin, pluginConfig])
-  })
-
   beforeEach(() => {
-    mockGet.mockClear()
+    mockGet.mockReset()
+    mockStart.mockClear()
   })
 
-  it('should expose $fingerprint global property with getVisitorData', () => {
-    mount({
-      template: '<h1>Hello world</h1>',
-      mounted() {
-        const $fingerprint = (this as any).$fingerprint
-
-        expect($fingerprint).toBeDefined()
-        expect($fingerprint.getVisitorData).toBeDefined()
-        expect(typeof $fingerprint.getVisitorData).toBe('function')
-      },
-    })
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
-  it('should support fetching data using $fingerprint.getVisitorData()', async () => {
+  it('exposes $fingerprint.getVisitorData on component instances', () => {
+    mountWithPlugin(
+      defineComponent({
+        template: '<h1>Hello world</h1>',
+        mounted() {
+          const { $fingerprint } = this
+
+          expect($fingerprint).toBeDefined()
+          expect(typeof $fingerprint.getVisitorData).toBe('function')
+        },
+      })
+    )
+  })
+
+  it('fetches visitor data through $fingerprint.getVisitorData()', async () => {
     mockGet.mockResolvedValue(testData)
 
-    const { vm } = mount({
+    const { vm } = mountWithPlugin({
       template: '<h1>Hello world</h1>',
     })
 
-    const result = await vm.$fingerprint.getVisitorData()
-
-    expect(result).toEqual(testData)
+    await expect(vm.$fingerprint.getVisitorData()).resolves.toEqual(testData)
   })
 
-  it('should throw if old loadOptions config shape is used', () => {
+  it('rejects deprecated loadOptions config shape', () => {
+    const deprecatedOptions = {
+      apiKey: 'test',
+      loadOptions: { apiKey: 'test' },
+    }
+
     expect(() => {
       const app = createApp(EmptyComponent)
-      app.use(FingerprintPlugin, { loadOptions: { apiKey: 'test' } } as any)
+      app.use(FingerprintPlugin, deprecatedOptions)
     }).toThrow(/loadOptions/)
   })
 
-  it('should fail fast when apiKey is missing', () => {
-    expect(() => {
-      const app = createApp(EmptyComponent)
-      app.use(FingerprintPlugin, undefined as any)
-    }).toThrow(/apiKey/)
+  it('rejects getVisitorData outside the browser before starting the agent', async () => {
+    const fingerprint = getMountedFingerprintClient({ apiKey: 'test-key' })
+
+    vi.stubGlobal('window', undefined)
+
+    await expect(fingerprint.getVisitorData()).rejects.toThrow(/only be called in the browser/)
+    expect(mockStart).not.toHaveBeenCalled()
   })
 
-  it('should call start() with integrationInfo appended on first getVisitorData call', async () => {
-    mockStart.mockClear()
+  it('appends integrationInfo when the agent starts and reuses the agent afterwards', async () => {
     mockGet.mockResolvedValue(testData)
 
-    const app = createApp(EmptyComponent)
-    app.use(FingerprintPlugin, { apiKey: 'test-key' })
+    const fingerprint = getMountedFingerprintClient({ apiKey: 'test-key' })
 
     expect(mockStart).not.toHaveBeenCalled()
 
-    const vm = app.mount(document.createElement('div')) as any
-    await vm.$fingerprint.getVisitorData()
+    await fingerprint.getVisitorData()
+    await fingerprint.getVisitorData()
 
     expect(mockStart).toHaveBeenCalledTimes(1)
-
-    // Verify agent reuse on subsequent calls
-    await vm.$fingerprint.getVisitorData()
-    expect(mockStart).toHaveBeenCalledTimes(1)
-
-    const callArgs = mockStart.mock.calls[0][0] as any
-    expect(callArgs.apiKey).toBe('test-key')
-    expect(callArgs.integrationInfo).toContain(`${INTEGRATION_INFO_PACKAGE_NAME}/${packageInfo.version}`)
+    expect(mockStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'test-key',
+        integrationInfo: expect.arrayContaining([`fingerprintjs-pro-vue-v3/${packageInfo.version}`]),
+      })
+    )
   })
 
-  it('should preserve existing integrationInfo entries', async () => {
-    mockStart.mockClear()
+  it('preserves existing integrationInfo entries', async () => {
     mockGet.mockResolvedValue(testData)
 
-    const app = createApp(EmptyComponent)
-    app.use(FingerprintPlugin, { apiKey: 'test-key', integrationInfo: ['custom/1.0'] })
+    const fingerprint = getMountedFingerprintClient({
+      apiKey: 'test-key',
+      integrationInfo: ['custom/1.0'],
+    })
 
-    const vm = app.mount(document.createElement('div')) as any
-    await vm.$fingerprint.getVisitorData()
+    await fingerprint.getVisitorData()
 
     expect(mockStart).toHaveBeenCalledTimes(1)
-    const callArgs = mockStart.mock.calls[0][0] as any
-    expect(callArgs.integrationInfo).toContain('custom/1.0')
-    expect(callArgs.integrationInfo).toContain(`${INTEGRATION_INFO_PACKAGE_NAME}/${packageInfo.version}`)
+    expect(mockStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationInfo: expect.arrayContaining(['custom/1.0', `fingerprintjs-pro-vue-v3/${packageInfo.version}`]),
+      })
+    )
   })
 })

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,13 +1,9 @@
-import { vi, type Mock } from 'vitest'
+import { vi } from 'vitest'
 
-export const mockGet: Mock<[], Promise<unknown>> = vi.fn()
-export const mockStart: Mock<[options?: unknown], { get: typeof mockGet }> = vi.fn((options?: unknown) => {
-  void options
-
-  return {
-    get: mockGet,
-  }
-})
+export const mockGet = vi.fn()
+export const mockStart = vi.fn(() => ({
+  get: mockGet,
+}))
 
 vi.mock('@fingerprint/agent', async () => {
   const actual = await vi.importActual('@fingerprint/agent')

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,7 +1,7 @@
-import { vi } from 'vitest'
+import { type MockInstance, vi } from 'vitest'
 
-export const mockGet = vi.fn()
-export const mockStart = vi.fn(() => ({
+export const mockGet: MockInstance = vi.fn()
+export const mockStart: MockInstance = vi.fn(() => ({
   get: mockGet,
 }))
 

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,7 +1,7 @@
-import { vi } from 'vitest'
+import { vi, type Mock } from 'vitest'
 
-export const mockGet = vi.fn()
-export const mockStart = vi.fn((options?: unknown) => {
+export const mockGet: Mock<[], Promise<unknown>> = vi.fn()
+export const mockStart: Mock<[options?: unknown], { get: typeof mockGet }> = vi.fn((options?: unknown) => {
   void options
 
   return {

--- a/__tests__/useVisitorData.test.ts
+++ b/__tests__/useVisitorData.test.ts
@@ -1,393 +1,271 @@
-import { config, mount } from '@vue/test-utils'
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
-import { FingerprintPlugin } from '../src/plugin'
-import type { FingerprintPluginOptions } from '../src/types'
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useVisitorData } from '../src'
-import { getCurrentInstance, nextTick, onMounted, ref, watch } from 'vue'
+import type { UseGetVisitorDataResult, UseVisitorDataOptions } from '../src'
+import type { GetOptions } from '@fingerprint/agent'
+import type { FingerprintVueGlobalClient } from '../src'
+import { defineComponent, getCurrentInstance, nextTick } from 'vue'
+import { deferred, flushPromises, mountWithPlugin, testData } from './helpers'
 import { mockGet, mockStart } from './setup'
 
-const apiKey = 'API_KEY'
-const testData = {
-  visitor_id: '#visitor_id',
-  event_id: 'event123',
-  sealed_result: null,
+function mountUseVisitorData(options: UseVisitorDataOptions = {}) {
+  let api!: UseGetVisitorDataResult
+
+  mountWithPlugin(
+    defineComponent({
+      template: '<div />',
+      setup() {
+        api = useVisitorData(options)
+
+        return {}
+      },
+    })
+  )
+
+  return { api }
 }
 
-const pluginConfig: FingerprintPluginOptions = {
-  apiKey,
-}
+const getDataOptionCases = [
+  {
+    name: 'passes per-call GetOptions to agent.get()',
+    composableOptions: { immediate: false },
+    callOptions: { tag: 'test', linkedId: 'link123' },
+    expectedOptions: { tag: 'test', linkedId: 'link123' },
+  },
+  {
+    name: 'merges default GetOptions with per-call options',
+    composableOptions: { immediate: false, tag: 'default-tag' },
+    callOptions: { linkedId: 'link456' },
+    expectedOptions: { tag: 'default-tag', linkedId: 'link456' },
+  },
+  {
+    name: 'lets per-call options override default options',
+    composableOptions: { immediate: false, tag: 'default-tag' },
+    callOptions: { tag: 'override-tag' },
+    expectedOptions: { tag: 'override-tag' },
+  },
+] satisfies Array<{
+  name: string
+  composableOptions: UseVisitorDataOptions
+  callOptions: GetOptions
+  expectedOptions: GetOptions
+}>
 
 describe('useVisitorData', () => {
-  beforeAll(() => {
-    config.global.plugins.push([FingerprintPlugin, pluginConfig])
-  })
-
   beforeEach(() => {
-    mockGet.mockClear()
+    mockGet.mockReset()
     mockStart.mockClear()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
-  it('should expose data, getData, isLoading, isFetched, and error', () => {
-    mount({
-      template: '<h1>Hello world</h1>',
-      setup() {
-        const { data, getData, isLoading, isFetched, error } = useVisitorData({ immediate: false })
-
-        expect(data.value).toBeUndefined()
-        expect(typeof getData === 'function').toBe(true)
-        expect(error.value).toBeUndefined()
-        expect(isLoading.value).toBe(false)
-        expect(isFetched.value).toBe(false)
-      },
-    })
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
-  it('should call getData on mount by default (immediate=true)', async () => {
+  it('exposes idle refs and an imperative getter when immediate is false', () => {
+    const { api } = mountUseVisitorData({ immediate: false })
+
+    expect(api.data.value).toBeUndefined()
+    expect(typeof api.getData).toBe('function')
+    expect(api.error.value).toBeUndefined()
+    expect(api.isLoading.value).toBe(false)
+    expect(api.isFetched.value).toBe(false)
+  })
+
+  it('fetches visitor data on mount by default', async () => {
     mockGet.mockResolvedValue(testData)
 
-    await new Promise<void>((resolve) => {
-      mount({
-        template: '<h1>Hello world</h1>',
-        setup() {
-          const { isLoading, data, isFetched } = useVisitorData()
+    const { api } = mountUseVisitorData()
 
-          onMounted(() => {
-            expect(isLoading.value).toBe(true)
-            expect(mockStart).toHaveBeenCalledTimes(1)
-          })
+    expect(api.isLoading.value).toBe(true)
+    expect(mockStart).toHaveBeenCalledTimes(1)
 
-          watch(isLoading, (currentLoading, wasLoading) => {
-            if (!currentLoading && wasLoading) {
-              expect(data.value).toEqual(testData)
-              expect(isFetched.value).toBe(true)
+    await flushPromises()
 
-              resolve()
-            }
-          })
-        },
-      })
-    })
+    expect(api.data.value).toEqual(testData)
+    expect(api.isFetched.value).toBe(true)
+    expect(api.isLoading.value).toBe(false)
   })
 
-  it('should reuse the same agent across multiple useVisitorData instances', async () => {
+  it('does not fetch visitor data on mount when immediate is false', () => {
+    const { api } = mountUseVisitorData({ immediate: false })
+
+    expect(api.isLoading.value).toBe(false)
+    expect(api.isFetched.value).toBe(false)
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  it('reuses the same agent across multiple useVisitorData instances', async () => {
     mockGet.mockResolvedValue(testData)
 
-    await new Promise<void>((resolve) => {
-      mount({
-        template: '<h1>Hello world</h1>',
+    let first!: UseGetVisitorDataResult
+    let second!: UseGetVisitorDataResult
+
+    mountWithPlugin(
+      defineComponent({
+        template: '<div />',
         setup() {
-          const firstVisitorData = useVisitorData({ immediate: false })
-          const secondVisitorData = useVisitorData({ immediate: false })
+          first = useVisitorData({ immediate: false })
+          second = useVisitorData({ immediate: false })
 
-          onMounted(async () => {
-            const firstResult = await firstVisitorData.getData()
-            const secondResult = await secondVisitorData.getData({ tag: 'second-instance' })
-
-            expect(firstResult).toEqual(testData)
-            expect(secondResult).toEqual(testData)
-            expect(mockGet).toHaveBeenCalledTimes(2)
-            expect(mockStart).toHaveBeenCalledTimes(1)
-
-            resolve()
-          })
+          return {}
         },
-      })
-    })
-  })
-
-  it('should reuse the same agent between useVisitorData and $fingerprint.getVisitorData', async () => {
-    mockGet.mockResolvedValue(testData)
-
-    await new Promise<void>((resolve) => {
-      mount({
-        template: '<h1>Hello world</h1>',
-        setup() {
-          const { getData } = useVisitorData({ immediate: false })
-          const instance = getCurrentInstance()
-
-          if (!instance?.proxy) {
-            throw new Error('Expected current component instance')
-          }
-
-          const fingerprint = instance.proxy.$fingerprint
-
-          onMounted(async () => {
-            const composableResult = await getData()
-            const pluginResult = await fingerprint.getVisitorData({ tag: 'plugin-call' })
-
-            expect(composableResult).toEqual(testData)
-            expect(pluginResult).toEqual(testData)
-            expect(mockGet).toHaveBeenCalledTimes(2)
-            expect(mockStart).toHaveBeenCalledTimes(1)
-
-            resolve()
-          })
-        },
-      })
-    })
-  })
-
-  it('should keep isFetched false on error and expose error', async () => {
-    const testError = new Error('Test error')
-    mockGet.mockRejectedValue(testError)
-
-    await new Promise<void>((resolve) => {
-      mount({
-        template: '<h1>Hello world</h1>',
-        setup() {
-          const { isLoading, isFetched, error } = useVisitorData()
-
-          onMounted(() => {
-            expect(isLoading.value).toBe(true)
-            expect(isFetched.value).toBe(false)
-          })
-
-          watch(isLoading, (currentLoading, wasLoading) => {
-            if (!currentLoading && wasLoading) {
-              expect(isFetched.value).toBe(false)
-              expect(error.value).toBeTruthy()
-
-              resolve()
-            }
-          })
-        },
-      })
-    })
-  })
-
-  it('should reject when getData() fails', async () => {
-    const testError = new Error('Test error')
-    mockGet.mockRejectedValue(testError)
-
-    await new Promise<void>((resolve) => {
-      mount({
-        template: '<h1>Hello world</h1>',
-        setup() {
-          const { getData, error } = useVisitorData({ immediate: false })
-
-          onMounted(async () => {
-            await expect(getData()).rejects.toThrow('Test error')
-            expect(error.value).toBeTruthy()
-            expect(error.value?.message).toBe('Test error')
-            expect(error.value?.name).toBe('Error')
-
-            resolve()
-          })
-        },
-      })
-    })
-  })
-
-  it('should normalize non-Error failures consistently', async () => {
-    mockGet.mockRejectedValue('Test failure')
-
-    await new Promise<void>((resolve) => {
-      mount({
-        template: '<h1>Hello world</h1>',
-        setup() {
-          const { getData, error } = useVisitorData({ immediate: false })
-
-          onMounted(async () => {
-            const thrown = await getData().catch((caughtError) => caughtError)
-
-            expect(thrown).toBeInstanceOf(Error)
-            expect(thrown.message).toBe('Test failure')
-            expect(error.value).toBe(thrown)
-
-            resolve()
-          })
-        },
-      })
-    })
-  })
-
-  it('should provide fresh data after error recovery', async () => {
-    mockGet.mockRejectedValueOnce(new Error('Test error'))
-
-    await new Promise<void>((resolve) => {
-      mount({
-        template: '<h1>Hello world</h1>',
-        setup() {
-          const { isLoading, getData, error, data, isFetched } = useVisitorData({ immediate: true })
-
-          const didRefetch = ref(false)
-          const checkedError = ref(false)
-
-          onMounted(() => {
-            expect(isLoading.value).toBe(true)
-          })
-
-          watch(isLoading, async (currentLoading, wasLoading) => {
-            if (!currentLoading && wasLoading && !checkedError.value) {
-              expect(error.value).toBeTruthy()
-              expect(isFetched.value).toBe(false)
-
-              checkedError.value = true
-
-              mockGet.mockResolvedValue(testData)
-
-              await getData()
-
-              didRefetch.value = true
-
-              resolve()
-            }
-          })
-
-          watch(didRefetch, (value) => {
-            if (value) {
-              expect(data.value).toEqual(testData)
-              expect(error.value).toBeUndefined()
-              expect(isFetched.value).toBe(true)
-
-              resolve()
-            }
-          })
-        },
-      })
-    })
-  })
-
-  it('should not call getData if `immediate` is set to false', () => {
-    mount({
-      template: '<h1>Hello world</h1>',
-      setup() {
-        const { isLoading } = useVisitorData({ immediate: false })
-
-        onMounted(() => {
-          expect(isLoading.value).toBe(false)
-          expect(mockGet).not.toHaveBeenCalled()
-        })
-      },
-    })
-  })
-
-  it('should pass GetOptions to agent.get()', async () => {
-    mockGet.mockResolvedValue(testData)
-
-    await new Promise<void>((resolve) => {
-      mount({
-        template: '<h1>Hello world</h1>',
-        setup() {
-          const { getData, isLoading } = useVisitorData({ immediate: false })
-
-          onMounted(async () => {
-            const result = await getData({ tag: 'test', linkedId: 'link123' })
-            expect(result).toEqual(testData)
-          })
-
-          watch(isLoading, (currentLoading, wasLoading) => {
-            if (!currentLoading && wasLoading) {
-              expect(mockGet).toHaveBeenCalledTimes(1)
-              expect(mockGet).toHaveBeenCalledWith({ tag: 'test', linkedId: 'link123' })
-
-              resolve()
-            }
-          })
-        },
-      })
-    })
-  })
-
-  it('should merge default GetOptions from useVisitorData with per-call options', async () => {
-    mockGet.mockResolvedValue(testData)
-
-    await new Promise<void>((resolve) => {
-      mount({
-        template: '<h1>Hello world</h1>',
-        setup() {
-          const { getData, isLoading } = useVisitorData({ immediate: false, tag: 'default-tag' })
-
-          onMounted(async () => {
-            await getData({ linkedId: 'link456' })
-          })
-
-          watch(isLoading, (currentLoading, wasLoading) => {
-            if (!currentLoading && wasLoading) {
-              expect(mockGet).toHaveBeenCalledTimes(1)
-              expect(mockGet).toHaveBeenCalledWith({ tag: 'default-tag', linkedId: 'link456' })
-
-              resolve()
-            }
-          })
-        },
-      })
-    })
-  })
-
-  it('should allow per-call options to override default options', async () => {
-    mockGet.mockResolvedValue(testData)
-
-    await new Promise<void>((resolve) => {
-      mount({
-        template: '<h1>Hello world</h1>',
-        setup() {
-          const { getData, isLoading } = useVisitorData({ immediate: false, tag: 'default-tag' })
-
-          onMounted(async () => {
-            await getData({ tag: 'override-tag' })
-          })
-
-          watch(isLoading, (currentLoading, wasLoading) => {
-            if (!currentLoading && wasLoading) {
-              expect(mockGet).toHaveBeenCalledTimes(1)
-              expect(mockGet).toHaveBeenCalledWith({ tag: 'override-tag' })
-
-              resolve()
-            }
-          })
-        },
-      })
-    })
-  })
-
-  it('should clear stale error and data immediately when getData() is called again', async () => {
-    // First call fails so error/data are populated.
-    mockGet.mockRejectedValueOnce(new Error('Test error'))
-
-    // Second call: a deferred promise so we can inspect mid-flight refs before it resolves.
-    let resolveSecond!: (value: typeof testData) => void
-    mockGet.mockReturnValueOnce(
-      new Promise<typeof testData>((resolve) => {
-        resolveSecond = resolve
       })
     )
 
-    await new Promise<void>((done) => {
-      mount({
-        template: '<h1>Hello world</h1>',
+    await expect(first.getData()).resolves.toEqual(testData)
+    await expect(second.getData({ tag: 'second-instance' })).resolves.toEqual(testData)
+
+    expect(mockGet).toHaveBeenCalledTimes(2)
+    expect(mockStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('reuses the same agent between useVisitorData and $fingerprint.getVisitorData', async () => {
+    mockGet.mockResolvedValue(testData)
+
+    let fingerprint: FingerprintVueGlobalClient | undefined
+
+    let api!: UseGetVisitorDataResult
+
+    mountWithPlugin(
+      defineComponent({
+        template: '<div />',
         setup() {
-          const { getData, error, data, isLoading, isFetched } = useVisitorData({ immediate: true })
+          api = useVisitorData({ immediate: false })
 
-          let retried = false
+          const instance = getCurrentInstance()
 
-          watch(isLoading, async (current, was) => {
-            if (current || !was || retried) {
-              return
-            }
+          if (!instance?.proxy?.$fingerprint) {
+            throw new Error('Expected $fingerprint on the component instance')
+          }
 
-            // First call has just settled with an error.
-            retried = true
-            expect(error.value).toBeTruthy()
+          fingerprint = instance.proxy.$fingerprint
 
-            // Start the retry but don't await it — we want to assert state mid-flight.
-            const pending = getData()
-
-            // Flush the synchronous reset that happens at the top of getData().
-            await nextTick()
-
-            expect(isLoading.value).toBe(true)
-            expect(error.value).toBeUndefined()
-            expect(data.value).toBeUndefined()
-            expect(isFetched.value).toBe(false)
-
-            // Resolve the deferred so the test can settle cleanly.
-            resolveSecond(testData)
-            await pending
-            done()
-          })
+          return {}
         },
       })
-    })
+    )
+
+    if (!fingerprint) {
+      throw new Error('Expected $fingerprint on the component instance')
+    }
+
+    await expect(api.getData()).resolves.toEqual(testData)
+    await expect(fingerprint.getVisitorData({ tag: 'plugin-call' })).resolves.toEqual(testData)
+
+    expect(mockGet).toHaveBeenCalledTimes(2)
+    expect(mockStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws when used without installing the plugin', () => {
+    expect(() => {
+      mount(
+        defineComponent({
+          template: '<div />',
+          setup() {
+            useVisitorData()
+
+            return {}
+          },
+        })
+      )
+    }).toThrow(/GET_VISITOR_DATA inject data is missing/)
+  })
+
+  it('stores mount-time errors without marking the fetch as complete', async () => {
+    const testError = new Error('Test error')
+    mockGet.mockRejectedValue(testError)
+
+    const { api } = mountUseVisitorData()
+
+    expect(api.isLoading.value).toBe(true)
+    expect(api.isFetched.value).toBe(false)
+
+    await flushPromises()
+
+    expect(api.isFetched.value).toBe(false)
+    expect(api.isLoading.value).toBe(false)
+    expect(api.error.value).toBe(testError)
+    expect(console.error).toHaveBeenCalledWith(`Failed to fetch visitor data on mount: ${testError}`)
+  })
+
+  it('rejects imperative getData() failures and stores the error', async () => {
+    const testError = new Error('Test error')
+    mockGet.mockRejectedValue(testError)
+
+    const { api } = mountUseVisitorData({ immediate: false })
+
+    await expect(api.getData()).rejects.toThrow('Test error')
+
+    expect(api.error.value).toBe(testError)
+    expect(api.isFetched.value).toBe(false)
+    expect(api.isLoading.value).toBe(false)
+  })
+
+  it('normalizes non-Error rejections while preserving the rejection value', async () => {
+    mockGet.mockRejectedValue('Test error')
+
+    const { api } = mountUseVisitorData({ immediate: false })
+
+    await expect(api.getData()).rejects.toBe('Test error')
+
+    expect(api.error.value).toBeInstanceOf(Error)
+    expect(api.error.value?.message).toBe('Test error')
+    expect(api.isFetched.value).toBe(false)
+  })
+
+  it('provides fresh data after a failed fetch', async () => {
+    mockGet.mockRejectedValueOnce(new Error('Test error'))
+
+    const { api } = mountUseVisitorData()
+
+    await flushPromises()
+
+    mockGet.mockResolvedValueOnce(testData)
+
+    await expect(api.getData()).resolves.toEqual(testData)
+
+    expect(api.data.value).toEqual(testData)
+    expect(api.error.value).toBeUndefined()
+    expect(api.isFetched.value).toBe(true)
+  })
+
+  it.each(getDataOptionCases)('$name', async ({ composableOptions, callOptions, expectedOptions }) => {
+    mockGet.mockResolvedValue(testData)
+
+    const { api } = mountUseVisitorData(composableOptions)
+
+    await api.getData(callOptions)
+
+    expect(mockGet).toHaveBeenCalledTimes(1)
+    expect(mockGet).toHaveBeenCalledWith(expectedOptions)
+  })
+
+  it('clears stale error and data immediately when a retry begins', async () => {
+    const testError = new Error('Test error')
+    const retry = deferred<typeof testData>()
+
+    mockGet.mockRejectedValueOnce(testError)
+    mockGet.mockReturnValueOnce(retry.promise)
+
+    const { api } = mountUseVisitorData()
+
+    await flushPromises()
+
+    expect(api.error.value).toBe(testError)
+    expect(api.isFetched.value).toBe(false)
+
+    const pending = api.getData()
+
+    await nextTick()
+
+    expect(api.isLoading.value).toBe(true)
+    expect(api.error.value).toBeUndefined()
+    expect(api.data.value).toBeUndefined()
+    expect(api.isFetched.value).toBe(false)
+
+    retry.resolve(testData)
+    await pending
   })
 })

--- a/__tests__/useVisitorData.test.ts
+++ b/__tests__/useVisitorData.test.ts
@@ -268,5 +268,10 @@ describe('useVisitorData', () => {
 
     retry.resolve(testData)
     await pending
+
+    expect(api.data.value).toEqual(testData)
+    expect(api.error.value).toBeUndefined()
+    expect(api.isFetched.value).toBe(true)
+    expect(api.isLoading.value).toBe(false)
   })
 })

--- a/__tests__/useVisitorData.test.ts
+++ b/__tests__/useVisitorData.test.ts
@@ -29,9 +29,9 @@ function mountUseVisitorData(options: UseVisitorDataOptions = {}) {
 const getDataOptionCases = [
   {
     name: 'passes per-call GetOptions to agent.get()',
-    composableOptions: { immediate: false },
-    callOptions: { tag: 'test', linkedId: 'link123' },
-    expectedOptions: { tag: 'test', linkedId: 'link123' },
+    composableOptions: { immediate: false, linkedId: 'default-link' },
+    callOptions: { tag: 'test' },
+    expectedOptions: { tag: 'test', linkedId: 'default-link' },
   },
   {
     name: 'merges default GetOptions with per-call options',
@@ -41,9 +41,9 @@ const getDataOptionCases = [
   },
   {
     name: 'lets per-call options override default options',
-    composableOptions: { immediate: false, tag: 'default-tag' },
+    composableOptions: { immediate: false, tag: 'default-tag', linkedId: 'default-link' },
     callOptions: { tag: 'override-tag' },
-    expectedOptions: { tag: 'override-tag' },
+    expectedOptions: { tag: 'override-tag', linkedId: 'default-link' },
   },
 ] satisfies Array<{
   name: string

--- a/__tests__/useVisitorData.test.ts
+++ b/__tests__/useVisitorData.test.ts
@@ -1,3 +1,4 @@
+/* exslint-disable vue/one-component-per-file */
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useVisitorData } from '../src'
@@ -13,12 +14,12 @@ function mountUseVisitorData(options: UseVisitorDataOptions = {}) {
 
   mountWithPlugin(
     defineComponent({
-      template: '<div />',
       setup() {
         api = useVisitorData(options)
 
         return {}
       },
+      template: '<div />',
     })
   )
 
@@ -104,13 +105,13 @@ describe('useVisitorData', () => {
 
     mountWithPlugin(
       defineComponent({
-        template: '<div />',
         setup() {
           first = useVisitorData({ immediate: false })
           second = useVisitorData({ immediate: false })
 
           return {}
         },
+        template: '<div />',
       })
     )
 
@@ -130,7 +131,6 @@ describe('useVisitorData', () => {
 
     mountWithPlugin(
       defineComponent({
-        template: '<div />',
         setup() {
           api = useVisitorData({ immediate: false })
 
@@ -144,6 +144,7 @@ describe('useVisitorData', () => {
 
           return {}
         },
+        template: '<div />',
       })
     )
 
@@ -162,12 +163,12 @@ describe('useVisitorData', () => {
     expect(() => {
       mount(
         defineComponent({
-          template: '<div />',
           setup() {
             useVisitorData()
 
             return {}
           },
+          template: '<div />',
         })
       )
     }).toThrow(/GET_VISITOR_DATA inject data is missing/)

--- a/__tests__/useVisitorData.test.ts
+++ b/__tests__/useVisitorData.test.ts
@@ -1,4 +1,4 @@
-/* exslint-disable vue/one-component-per-file */
+/* eslint-disable vue/one-component-per-file */
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useVisitorData } from '../src'
@@ -204,12 +204,12 @@ describe('useVisitorData', () => {
     expect(api.isLoading.value).toBe(false)
   })
 
-  it('normalizes non-Error rejections while preserving the rejection value', async () => {
+  it('normalizes non-Error rejections into Error objects', async () => {
     mockGet.mockRejectedValue('Test error')
 
     const { api } = mountUseVisitorData({ immediate: false })
 
-    await expect(api.getData()).rejects.toBe('Test error')
+    await expect(api.getData()).rejects.toThrow('Test error')
 
     expect(api.error.value).toBeInstanceOf(Error)
     expect(api.error.value?.message).toBe('Test error')


### PR DESCRIPTION
## What changed
- refactored the Vue SDK test suite to use shared test helpers and local plugin setup
- replaced timer- and watcher-heavy async tests with deferred promises and direct behavior assertions
- added coverage for browser-only guards, missing plugin/injection failures, and non-Error rejection normalization

Testing 

* All tests pass
* Mutation testing successful - each test breaks in case of targeted implementation mutation

