### PR TITLE
fix: add id-token permission for npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write # Required for npm provenance / Trusted Publishing
+  contents: read
+
 jobs:
   build-and-release:
     name: "Build project, run CI checks and publish new release"


### PR DESCRIPTION
## Summary
- Add `permissions` block with `id-token: write` to the release workflow, required for npm provenance attestation via OIDC trusted publishing
- Mirrors the pattern used in [fingerprintjs/react](https://github.com/fingerprintjs/react/blob/main/.github/workflows/release.yml#L8)
- Fixes: https://github.com/fingerprintjs/vue/actions/runs/24501902076/job/71610619416

## Test plan
- [ ] Merge and trigger a release — verify the publish step succeeds with provenance