### PR TITLE
chore: remove unused tslib dependency

### DIFF
--- a/.changeset/remove-unused-tslib.md
+++ b/.changeset/remove-unused-tslib.md
@@ -1,0 +1,5 @@
+---
+"@fingerprint/vue": patch
+---
+
+Remove unused `tslib` runtime dependency.

--- a/package.json
+++ b/package.json
@@ -92,8 +92,7 @@
     "vue-tsc": "^2.0.6"
   },
   "dependencies": {
-    "@fingerprint/agent": "^4.0.0",
-    "tslib": "^2.6.2"
+    "@fingerprint/agent": "^4.0.0"
   },
   "peerDependencies": {
     "vue": "^3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@fingerprint/agent':
         specifier: ^4.0.0
         version: 4.0.3
-      tslib:
-        specifier: ^2.6.2
-        version: 2.6.2
     devDependencies:
       '@changesets/cli':
         specifier: ^2.30.0


### PR DESCRIPTION
`tslib` was a runtime dependency but the built output (`dist/fingerprint-vue.js` / `.mjs`) contains zero references to it — the `es2020` target emits no TS helpers, and Vite would inline any that were needed. Removes unnecessary weight from consumers' `node_modules`.

Verified: `pnpm build` clean, `grep tslib dist/*` returns 0, 27/27 tests pass.