### PR TITLE
docs: document caching default change INTER-1988

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 
   **Breaking changes:**
 
-  - The default caching strategy has changed from `sessionStorage` caching to **no caching by default**, aligned with the underlying [JavaScript agent v4 default](https://docs.fingerprint.com/reference/js-agent-v4-start-function#cache).
   - Replaced `@fingerprintjs/fingerprintjs-pro-spa` dependency with `@fingerprint/agent` v4
+  - The default caching strategy has changed from `sessionStorage` caching to **no caching by default**, aligned with the underlying [JavaScript agent v4 default](https://docs.fingerprint.com/reference/js-agent-v4-start-function#cache).
   - Plugin options are now passed directly instead of nested under `loadOptions` — use `{ apiKey: '...' }` instead of `{ loadOptions: { apiKey: '...' } }`
   - Renamed `fpjsPlugin` to `FingerprintPlugin`, `FpjsVueOptions` to `FingerprintPluginOptions`
   - Renamed `$fpjs` global property to `$fingerprint`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
   **Breaking changes:**
 
+  - The default caching strategy has changed from `sessionStorage` caching to **no caching by default**, aligned with the underlying [JavaScript agent v4 default](https://docs.fingerprint.com/reference/js-agent-v4-start-function#cache).
   - Replaced `@fingerprintjs/fingerprintjs-pro-spa` dependency with `@fingerprint/agent` v4
   - Plugin options are now passed directly instead of nested under `loadOptions` — use `{ apiKey: '...' }` instead of `{ loadOptions: { apiKey: '...' } }`
   - Renamed `fpjsPlugin` to `FingerprintPlugin`, `FpjsVueOptions` to `FingerprintPluginOptions`

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ const result = await agent.get();
 
 Fingerprint usage is billed per API call. To avoid unnecessary API calls, it is a good practice to [cache identification results](https://docs.fingerprint.com/docs/caching-visitor-information).
 
-Caching is off by default. You can configure caching using plugin [options](https://docs.fingerprint.com/reference/js-agent-v4-start-function#cacheconfig):
+Caching is disabled by default, aligned with the underlying [JavaScript agent v4 default](https://docs.fingerprint.com/reference/js-agent-v4-start-function#cache). To enable caching, pass the [`cache` start option](https://docs.fingerprint.com/reference/js-agent-v4-start-function#cacheconfig):
 
 ```typescript
 app.use(FingerprintPlugin, {


### PR DESCRIPTION
- Document the breaking change: default caching strategy changed from `sessionStorage` to **no caching** (aligned with JS agent v4 default)
- Update README caching section to clarify the behavior and link to JS agent v4 docs
- Add explicit breaking change entry in CHANGELOG v2.0.0